### PR TITLE
Fix bug where characters in the word the cursor was on where ignored

### DIFF
--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -52,10 +52,12 @@ export default function getHighlights(
   text: string,
   direction: "forward" | "reverse"
 ): { position: number; type: "primary" | "secondary" }[] {
-  const words = extractWords(text).filter(({ offset }) => offset > 0);
-
+  const words = extractWords(text);
+  const firstWord = words.shift().text;
   // Whether a character is already being used
   const occurrences = {};
+    
+  firstWord.split('').forEach(char => occurrences[char] = (occurrences[char] || 0) + 1);
 
   // Primary highlights
   const highlights = words.map(word =>

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -68,6 +68,14 @@ suite("Extension Tests", () => {
       "axxx [b]xxx [c]xxx [d]xxx [e]xxx [f]xxx"
     );
   });
+  
+    
+  test("Includes current word in character occurences", () => {
+    assertHighlights(
+      "abxx bxxx cxxx dxxx exxx fxxx",
+      "abxx <b>xxx [c]xxx [d]xxx [e]xxx [f]xxx"
+    );
+  });
 
   // TODO: tests for reverse
 });


### PR DESCRIPTION
Hey, thanks for the plugin! Found a small bug that should be fixed with the PR.

Given for example the sentence
"abxx bxx cxx"
    
If the cursor was on the "a" in "abxx", then the "b" in "bxx" would be considered a primary highlight.
It should be considered a secondary highlight